### PR TITLE
Dockerfile: use 0.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 MAINTAINER Johannes Mitlmeier <dev.jojomi@yahoo.com>
 
-ENV HUGO_VERSION=0.20.7
+ENV HUGO_VERSION=0.21
 ADD https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz /tmp
 RUN tar -xf /tmp/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -C /tmp \
     && mkdir -p /usr/local/sbin \


### PR DESCRIPTION
This PR bumps the Hugo version number to 0.21

- See release notes at: https://github.com/spf13/hugo/releases/tag/v0.21
- Note the tag only having 2 places (not a SemVer tag)