### PR TITLE
0.26 released

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 MAINTAINER Johannes Mitlmeier <dev.jojomi@yahoo.com>
 
 COPY ./run.sh /run.sh
-ENV HUGO_VERSION=0.25.1
+ENV HUGO_VERSION=0.26
 ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz /tmp
 RUN tar -xf /tmp/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -C /tmp \
     && mkdir -p /usr/local/sbin \


### PR DESCRIPTION
This PR updates the Hugo to 0.26.

[Release blog post](https://gohugo.io/news/0.26-relnotes/)