### PR TITLE
Bump up the version to 0.42.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL description="Docker container for building static sites with the Hugo stat
 LABEL maintainer="Johannes Mitlmeier <dev.jojomi@yahoo.com>"
 
 COPY ./run.sh /run.sh
-ENV HUGO_VERSION=0.42
+ENV HUGO_VERSION=0.42.1
 ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz /tmp
 RUN tar -xf /tmp/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz -C /tmp \
     && mkdir -p /usr/local/sbin \


### PR DESCRIPTION
This PR bumps up the version of Hugo to v0.42.1.

- https://gohugo.io/news/0.42.1-relnotes/