### PR TITLE
Move download of hugo into RUN command to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,10 @@ ENV HUGO_TYPE=_extended
 
 COPY ./run.sh /run.sh
 ENV HUGO_ID=hugo${HUGO_TYPE}_${HUGO_VERSION}
-ADD https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_ID}_Linux-64bit.tar.gz /tmp
-RUN tar -xf /tmp/${HUGO_ID}_Linux-64bit.tar.gz -C /tmp \
+RUN wget -O - https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_ID}_Linux-64bit.tar.gz | tar -xz -C /tmp \
     && mkdir -p /usr/local/sbin \
     && mv /tmp/hugo /usr/local/sbin/hugo \
     && rm -rf /tmp/${HUGO_ID}_linux_amd64 \
-    && rm -rf /tmp/${HUGO_ID}_Linux-64bit.tar.gz \
     && rm -rf /tmp/LICENSE.md \
     && rm -rf /tmp/README.md
 


### PR DESCRIPTION
Just a small adjustment that ends up saving ~15MB in the overall image size (from 105MB to 90.4MB).

## Explanation (in case it matters)
The `ADD` command will download the tar and put into the image in its own layer. The following `RUN` command extracts it and deletes it. While the tar isn't visible in a running container, it's still being shipped around in the layer it was downloaded. By combining these into the `RUN` command, the tar is never on the filesystem, so not included in the final image and shipped around.

And thanks for the image! 😄 