### PR TITLE
Bump to 0.81.0 Fix update.sh to be general, README to explain Docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL description="Docker container for building static sites with the Hugo stat
 LABEL maintainer="Johannes Mitlmeier <dev.jojomi@yahoo.com>"
 
 # config
-ENV HUGO_VERSION=0.76.5
+ENV HUGO_VERSION=0.81.0
 #ENV HUGO_TYPE=
 ENV HUGO_TYPE=_extended
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,97 @@
 # docker-hugo
 
-Docker image for hugo static page generator (https://gohugo.io)
-
+Docker image for hugo static page generator [Hugo](https://gohugo.io)
 
 ## Environment Variables
 
 * `HUGO_THEME`
 * `HUGO_WATCH` (set to any value to enable watching)
 * `HUGO_DESTINATION` (Path where hugo will render the site. By default `/output`)
-* `HUGO_REFRESH_TIME` (in seconds, only applies if not watching, if not set, the container will build once and exit)
-* `HUGO_BASEURL`
-
+* `HUGO_REFRESH_TIME` (in seconds, only applies if not watching, if not set,
+the container will build once and exit) `HUGO_BASEURL`
 
 ## Executing
 
-    docker run --name "my-hugo" -P -v $(pwd):/src jojomi/hugo
+```shell
+docker run --name "my-hugo" -P -v $(pwd):/src jojomi/hugo
+```
 
 Or, more verbosely, and with a specified output mapping:
 
-    docker run --name "my-hugo" --publish-all \
-           --volume $(pwd):/src \
-           --volume /tmp/hugo-build-output:/output \
-           jojomi/hugo
+```shell
+docker run --name "my-hugo" --publish-all \
+       --volume $(pwd):/src \
+       --volume /tmp/hugo-build-output:/output \
+       jojomi/hugo
+ ```
 
 Find your container:
 
-    docker ps | grep "my-hugo"
-    CONTAINER ID        IMAGE                           COMMAND                CREATED             STATUS              PORTS                   NAMES
-    ba00b5c238fc        jojomi/hugo:latest   "/run.sh"              7 seconds ago       Up 6 seconds        1313/tcp      my-hugo
+```shell
+$ docker ps | grep "my-hugo"
+CONTAINER ID        IMAGE                           COMMAND                CREATED             STATUS              PORTS                   NAMES
+ba00b5c238fc        jojomi/hugo:latest   "/run.sh"              7 seconds ago       Up 6 seconds        1313/tcp      my-hugo
+```
 
+## Update Image on Docker Hub
+
+First you want to connect this repo to Docker Hub so it
+[automatically](https://docs.docker.com/docker-hub/builds/link-source/) builds
+from a shell script just set the environment variable to your Docker
+organization and then release of Hugo you want. Note, this must be the full
+version number including the ".0" or minor release.
+
+If you have automatic build set, then as soon as you push to github, you will
+create the docker version:
+
+1. Go to [Docker Hub](https://hub.docker.com)
+2. Navigate on the upper left where you see your user name
+3. Goto Account Settings > Linked Accounts and authenticate with Github
+4. Go to repositories > Builds and select the Github repo
+5. Select the source Repo which is your github account/docker-hugo
+6. Make sure to Repository Links > Enable for Base Image
+7. Now everytime you do a push to master, the docker image will build.
+8. Make sure to add some new Build rules so you get
+   [tagging](https://stackoverflow.com/questions/25328166/docker-hub-automated-build-tagging)
+
+The regex is very complicated here, but basically it sets the name properly in
+the table, but you basically search the Github repo for the Tag name in github
+and then generate the appropriate Docker tag or you can look at the example
+build rules and copy what this does is to parse the Tag name looking for the
+[semver](https://semver.org)
+major, minor and patch and generating cascading tags
+
+| Type   | Name                              | Dockerfile Location | Docker Tag |
+|--------|-----------------------------------|---------------------|-----------------|
+| Branch | master                   | Dockerfile      | latest          |
+| Tag    | /^([0-9]+)\.([0-9]+)\.([0-9]+)$/ | Dockerfile  | {\1}            |
+| Tag    | /^([0-9]+)\.([0-9]+)\.([0-9]+)$/ | Dockerfile   | {\1}.{\2}       |
+| Tag    | /^([0-9]+)\.([0-9]+)\.([0-9]+)$/ | Dockerfile  | {\1}.{\2}.{\3}  |
+
+```shell
+export DOCKER_ORG=jojomi
+./update.sh 0.81.0
+# wait a little bit this will work
+docker pull $DOCKER_ORG/hugo:0.81.0
+```
 
 ## Building The Image Yourself (optional)
 
-    docker build -t jojomi/hugo:latest .
+```shell
+docker build -t jojomi/hugo:latest .
+```
 
 The image is conveniently small at **about 20 MB** thanks to [alpine](http://gliderlabs.viewdocs.io/docker-alpine):
 
-    docker images | grep hugo
-    jojomi/hugo:0.18   latest              b2e7a8364baa        1 second ago      21.9 MB
-
-
+```shell
+docker images | grep hugo
+jojomi/hugo:0.18   latest              b2e7a8364baa        1 second ago      21.9 MB
+```
 
 ## Creating a new tag
 
-Create a new git branch, change the line `ENV HUGO_VERSION=0.18` in `Dockerfile` and wire it in the Docker Hub accordingly.
-
+Create a new git branch, change the line `ENV HUGO_VERSION=0.18` in
+`Dockerfile` and wire it in the Docker Hub accordingly.
 
 ## docker-compose
 
@@ -52,7 +99,7 @@ Using this docker image together with nginx for serving static data.
 
 `docker-compose.yml`
 
-```
+```yaml
 hugo:
   image: jojomi/hugo:latest
   volumes:
@@ -79,7 +126,7 @@ web:
 
 `docker-compose.yml`
 
-```
+```yaml
 proxy:
   image: jwilder/nginx-proxy
   ports:
@@ -90,8 +137,3 @@ proxy:
     - vhost.d:/etc/nginx/vhost.d:ro
   restart: always
 ```
-
-
-## Update Image on Hugo Update
-
-```./update.sh 0.25```

--- a/update.sh
+++ b/update.sh
@@ -1,10 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # set -o xtrace
 
-VERSION=$1
+echo "usage: DOCKER_ORG=richt ./update.sh 0.81.0"
 
-PORT=1313
+VERSION="${VERSION:-"$1"}"
+DOCKER_ORG="${DOCKER_ORG:-jojomi}"
+PORT="${PORT:-1313}"
 NAME=test-hugo
+OUTPUT="${OUTPUT:-"$(mktemp)"}"
 
 # set version in Dockerfile
 sed -i "s/HUGO_VERSION=[0-9.]\+/HUGO_VERSION=$VERSION/g" Dockerfile
@@ -12,45 +15,48 @@ sed -i "s/HUGO_VERSION=[0-9.]\+/HUGO_VERSION=$VERSION/g" Dockerfile
 # cleanup container
 docker stop "$NAME"
 docker rm "$NAME"
-rm -rf test-output
+rm -rf "$OUTPUT"
 
 # build image
-docker build --no-cache=true --pull --tag jojomi/hugo:latest .
+docker build --no-cache=true --pull --tag "$DOCKER_ORG/hugo:$VERSION" .
 
 # verify image build
-docker images | grep jojomi/hugo | grep latest
+docker images | grep "$DOCKER_ORG/hugo" | grep "$VERSION"
 
 # run container
 mkdir --parents test-output
 docker run \
   --env HUGO_WATCH=true \
-  --env HUGO_BASEURL=http://localhost:$PORT \
+  --env "HUGO_BASEURL=http://localhost:$PORT" \
   --name "$NAME" \
-  --volume "$(pwd)/test-src:/src" \
-  --volume "$(pwd)/test-output:/output" \
+  --volume "$PWD/test-src:/src" \
+  --volume "$OUTPUT:/output" \
   --publish "$PORT:1313" \
   --detach \
-  jojomi/hugo:latest
+  "$DOCKER_ORG/hugo:$VERSION"
 docker ps | grep "$NAME"
 
 # verify output
-xdg-open http://localhost:$PORT > /dev/null
+OPEN="${OPEN:-xdg-open}"
+if [[ $OSTYPE =~ darwin ]]; then
+  OPEN=open
+fi
+"$OPEN" "http://localhost:$PORT" > /dev/null
 
 # ask for continuation
-read -r -p "Does it work? [y/N] " prompt
+read -r -p "Does it work if should I push to git hub? [y/N] " prompt
 
 # cleanup container
 docker stop "$NAME"
 docker rm "$NAME"
-sudo rm -rf test-output
+rm -rf "$OUTPUT"
 
-if [[ $prompt == "y" || $prompt == "Y" || $prompt == "yes" || $prompt == "Yes" ]]
+if [[ $prompt =~ ^[yY] ]]
 then
   # git: commit, tag, push
-  git add Dockerfile && git commit -m "version $VERSION" && git tag $VERSION && git push && git push --tags
+  git add Dockerfile && \
+    git commit -m "version $VERSION" && git tag "$VERSION" && git push && git push --tags
   # open hub.docker.com
-  xdg-open https://hub.docker.com/r/jojomi/hugo/builds/ > /dev/null
-  xdg-open https://hub.docker.com/r/jojomi/hugo/~/settings/automated-builds/ > /dev/null
+  "$OPEN" "https://hub.docker.com/r/$DOCKER_ORG/hugo/builds/" > /dev/null
+  "$OPEN" "https://hub.docker.com/r/$DOCKER_ORG/hugo/~/settings/automated-builds/" > /dev/null
 fi
-
-


### PR DESCRIPTION
This fixes #105 and it is a more robust update.sh which allows forking see github.com:richtong/docker-hugo for the latest commits...