### PR TITLE
HUGO_AppendPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Docker image for hugo static page generator (https://gohugo.io)
 * `HUGO_DESTINATION` (Path where hugo will render the site. By default `/output`)
 * `HUGO_REFRESH_TIME` (in seconds, only applies if not watching, if not set, the container will build once and exit)
 * `HUGO_BASEURL`
+* `HUGO_AppendPort` (set to false to prevent the default port to be appended to links)
 
 
 ## Executing

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker image for hugo static page generator (https://gohugo.io)
 * `HUGO_DESTINATION` (Path where hugo will render the site. By default `/output`)
 * `HUGO_REFRESH_TIME` (in seconds, only applies if not watching, if not set, the container will build once and exit)
 * `HUGO_BASEURL`
-* `HUGO_AppendPort` (set to false to prevent the default port to be appended to links)
+* `HUGO_APPEND_PORT` (set to false to prevent the default port to be appended to links)
 
 
 ## Executing

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+AppendPort="${HUGO_AppendPort:=true}"
 WATCH="${HUGO_WATCH:=false}"
 SLEEP="${HUGO_REFRESH_TIME:=-1}"
 HUGO_DESTINATION="${HUGO_DESTINATION:=/output}"
@@ -12,14 +13,20 @@ echo "ARGS" $@
 HUGO=/usr/local/sbin/hugo
 echo "Hugo path: $HUGO"
 
+if [[ $HUGO_AppendPort != 'false' ]]; then
+    AppendPort="true"
+else
+    AppendPort="false"
+fi
+
 while [ true ]
 do
     if [[ $HUGO_WATCH != 'false' ]]; then
 	    echo "Watching..."
-        $HUGO server --watch=true --source="/src" --theme="$HUGO_THEME" --destination="$HUGO_DESTINATION" --baseURL="$HUGO_BASEURL" --bind="0.0.0.0" "$@" || exit 1
+        $HUGO server --watch=true --source="/src" --appendPort="$AppendPort" --theme="$HUGO_THEME" --destination="$HUGO_DESTINATION" --baseURL="$HUGO_BASEURL" --bind="0.0.0.0" "$@" || exit 1
     else
 	    echo "Building one time..."
-        $HUGO --source="/src" --theme="$HUGO_THEME" --destination="$HUGO_DESTINATION" --baseURL="$HUGO_BASEURL" "$@" || exit 1
+        $HUGO --source="/src" --appendPort="$AppendPort" --theme="$HUGO_THEME" --destination="$HUGO_DESTINATION" --baseURL="$HUGO_BASEURL" "$@" || exit 1
     fi
 
     if [[ $HUGO_REFRESH_TIME == -1 ]]; then

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-AppendPort="${HUGO_AppendPort:=true}"
+HUGO_APPEND_PORT="${HUGO_APPEND_PORT:=true}"
 WATCH="${HUGO_WATCH:=false}"
 SLEEP="${HUGO_REFRESH_TIME:=-1}"
 HUGO_DESTINATION="${HUGO_DESTINATION:=/output}"
@@ -13,20 +13,20 @@ echo "ARGS" $@
 HUGO=/usr/local/sbin/hugo
 echo "Hugo path: $HUGO"
 
-if [[ $HUGO_AppendPort != 'false' ]]; then
-    AppendPort="true"
+if [[ $HUGO_APPEND_PORT != 'false' ]]; then
+    HUGO_APPEND_PORT="true"
 else
-    AppendPort="false"
+    HUGO_APPEND_PORT="false"
 fi
 
 while [ true ]
 do
     if [[ $HUGO_WATCH != 'false' ]]; then
 	    echo "Watching..."
-        $HUGO server --watch=true --source="/src" --appendPort="$AppendPort" --theme="$HUGO_THEME" --destination="$HUGO_DESTINATION" --baseURL="$HUGO_BASEURL" --bind="0.0.0.0" "$@" || exit 1
+        $HUGO server --watch=true --source="/src" --appendPort="$HUGO_APPEND_PORT" --theme="$HUGO_THEME" --destination="$HUGO_DESTINATION" --baseURL="$HUGO_BASEURL" --bind="0.0.0.0" "$@" || exit 1
     else
 	    echo "Building one time..."
-        $HUGO --source="/src" --appendPort="$AppendPort" --theme="$HUGO_THEME" --destination="$HUGO_DESTINATION" --baseURL="$HUGO_BASEURL" "$@" || exit 1
+        $HUGO --source="/src" --appendPort="$HUGO_APPEND_PORT" --theme="$HUGO_THEME" --destination="$HUGO_DESTINATION" --baseURL="$HUGO_BASEURL" "$@" || exit 1
     fi
 
     if [[ $HUGO_REFRESH_TIME == -1 ]]; then


### PR DESCRIPTION
This will add a env variable `HUGO_AppendPort` that can be used to disable the auto append of the hugo port to the links generated in pages

Fixes #66 

`HUGO_AppendPort=false`